### PR TITLE
Use UTF-8 when GUI reads/writes rules

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -7,14 +7,14 @@ RULES_FILE = "rules.json"
 def load_rules():
     if not os.path.exists(RULES_FILE):
         return []
-    with open(RULES_FILE, "r") as f:
+    with open(RULES_FILE, "r", encoding="utf-8", errors="ignore") as f:
         try:
             return json.load(f)
         except json.JSONDecodeError:
             return []
 
 def save_rules(rules):
-    with open(RULES_FILE, "w") as f:
+    with open(RULES_FILE, "w", encoding="utf-8", errors="ignore") as f:
         json.dump(rules, f, indent=2)
 
 def rule_to_display(rule):


### PR DESCRIPTION
## Summary
- open `rules.json` with UTF-8 in `load_rules` and `save_rules`

## Testing
- `python -m py_compile main.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_683f594d2c74832bb37db48454a507fe